### PR TITLE
Update ATtinyLoRa.cpp

### DIFF
--- a/ATtinyLoRa.cpp
+++ b/ATtinyLoRa.cpp
@@ -16,11 +16,71 @@
 ******************************************************************************************/
 #include "ATtinyLoRa.h"
 #include <tinySPI.h> //ATtiny85
-//#include <SPI.h>     // ATmega328p
+//#include <SPI.h>   // ATmega328p
 
 extern uint8_t NwkSkey[16];
 extern uint8_t AppSkey[16];
 extern uint8_t DevAddr[4];
+
+/*
+*****************************************************************************************
+* Description: TTN regional frequency plans
+*****************************************************************************************
+*/
+
+#ifdef AU915
+static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
+	{ 0xE5, 0x33, 0x5A },	//Channel 0 916.800 MHz / 61.035 Hz = 15020890 = 0xE5335A
+	{ 0xE5, 0x40, 0x26 },	//Channel 2 917.000 MHz / 61.035 Hz = 15024166 = 0xE54026
+	{ 0xE5, 0x4C, 0xF3 },	//Channel 3 917.200 MHz / 61.035 Hz = 15027443 = 0xE54CF3
+	{ 0xE5, 0x59, 0xC0 },	//Channel 4 917.400 MHz / 61.035 Hz = 15030720 = 0xE559C0
+	{ 0xE5, 0x66, 0x8D },	//Channel 5 917.600 MHz / 61.035 Hz = 15033997 = 0xE5668D
+	{ 0xE5, 0x73, 0x5A },	//Channel 6 917.800 MHz / 61.035 Hz = 15037274 = 0xE5735A
+	{ 0xE5, 0x80, 0x27 },	//Channel 7 918.000 MHz / 61.035 Hz = 15040551 = 0xE58027
+	{ 0xE5, 0x8C, 0xF3 }	//Channel 8 918.200 MHz / 61.035 Hz = 15043827 = 0xE58CF3
+};
+#endif
+
+#ifdef EU863
+static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
+	{ 0xD9, 0x06, 0x8B },	//Channel 0 868.100 MHz / 61.035 Hz = 14222987 = 0xD9068B
+	{ 0xD9, 0x13, 0x58 },	//Channel 1 868.300 MHz / 61.035 Hz = 14226264 = 0xD91358
+	{ 0xD9, 0x20, 0x24 },	//Channel 2 868.500 MHz / 61.035 Hz = 14229540 = 0xD92024
+	{ 0xD8, 0xC6, 0x8B },	//Channel 3 867.100 MHz / 61.035 Hz = 14206603 = 0xD8C68B
+	{ 0xD8, 0xD3, 0x58 },	//Channel 4 867.300 MHz / 61.035 Hz = 14209880 = 0xD8D358
+	{ 0xD8, 0xE0, 0x24 },	//Channel 5 867.500 MHz / 61.035 Hz = 14213156 = 0xD8E024
+	{ 0xD8, 0xEC, 0xF1 },	//Channel 6 867.700 MHz / 61.035 Hz = 14216433 = 0xD8ECF1
+	{ 0xD8, 0xF9, 0xBE }	//Channel 7 867.900 MHz / 61.035 Hz = 14219710 = 0xD8F9BE
+
+};
+#endif
+
+#ifdef US902
+static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
+	{ 0xE1, 0xF9, 0xC0 },		//Channel 0 903.900 MHz / 61.035 Hz = 14809536 = 0xE1F9C0
+	{ 0xE2, 0x06, 0x8C },		//Channel 1 904.100 MHz / 61.035 Hz = 14812812 = 0xE2068C
+	{ 0xE2, 0x13, 0x59},		//Channel 2 904.300 MHz / 61.035 Hz = 14816089 = 0xE21359
+	{ 0xE2, 0x20, 0x26 },		//Channel 3 904.500 MHz / 61.035 Hz = 14819366 = 0xE22026
+	{ 0xE2, 0x2C, 0xF3 },		//Channel 4 904.700 MHz / 61.035 Hz = 14822643 = 0xE22CF3
+	{ 0xE2, 0x39, 0xC0 },		//Channel 5 904.900 MHz / 61.035 Hz = 14825920 = 0xE239C0
+	{ 0xE2, 0x46, 0x8C },		//Channel 6 905.100 MHz / 61.035 Hz = 14829196 = 0xE2468C
+	{ 0xE2, 0x53, 0x59 }		//Channel 7 905.300 MHz / 61.035 Hz = 14832473 = 0xE25359
+};
+#endif
+
+#ifdef AS920
+static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
+	{ 0xE6, 0xCC, 0xF4 },		//Channel 0 868.100 MHz / 61.035 Hz = 15125748 = 0xE6CCF4
+	{ 0xE6, 0xD9, 0xC0 },		//Channel 1 868.300 MHz / 61.035 Hz = 15129024 = 0xE6D9C0
+	{ 0xE6, 0x8C, 0xF3 },		//Channel 2 868.500 MHz / 61.035 Hz = 15109363 = 0xE68CF3
+	{ 0xE6, 0x99, 0xC0 },		//Channel 3 867.100 MHz / 61.035 Hz = 15112640 = 0xE699C0
+	{ 0xE6, 0xA6, 0x8D },		//Channel 4 867.300 MHz / 61.035 Hz = 15115917 = 0xE6A68D
+	{ 0xE6, 0xB3, 0x5A },		//Channel 5 867.500 MHz / 61.035 Hz = 15119194 = 0xE6B35A
+	{ 0xE6, 0xC0, 0x27 },		//Channel 6 867.700 MHz / 61.035 Hz = 15122471 = 0xE6C027
+	{ 0xE6, 0x80, 0x27 }		//Channel 7 867.900 MHz / 61.035 Hz = 15106087 = 0xE68027
+};
+#endif
+
 
 /*
 *****************************************************************************************
@@ -90,6 +150,9 @@ void TinyLoRa::begin()
   // init frame counter
   uint16_t frameCounter = 0x0000;
 
+  // init tx random number for first use
+  uint8_t txrandomNum = 0x00;
+
 }
 /*
 *****************************************************************************************
@@ -113,39 +176,53 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
   RFM_Write(0x40,0x40);
 
   // change the channel of the RFM module
-  switch (randomNum) {
-      case 0x00: //Channel 0 868.100 MHz / 61.035 Hz = 14222987 = 0xD9068B
-        RFM_Write(0x06,0xD9);
-        RFM_Write(0x07,0x06);
-        RFM_Write(0x08,0x8B);
-        break;
-      case 0x01: //Channel 1 868.300 MHz / 61.035 Hz = 14226264 = 0xD91358
-        RFM_Write(0x06,0xD9);
-        RFM_Write(0x07,0x13);
-        RFM_Write(0x08,0x58);
-        break;
-      case 0x02: //Channel 2 868.500 MHz / 61.035 Hz = 14229540 = 0xD92024
-        RFM_Write(0x06,0xD9);
-        RFM_Write(0x07,0x20);
-        RFM_Write(0x08,0x24);
-        break;
-      case 0x03: //Channel 3 867.100 MHz / 61.035 Hz = 14206603 = 0xD8C68B
-	RFM_Write(0x06,0xD8);
-	RFM_Write(0x07,0xC6);
-	RFM_Write(0x08,0x8B);
-        break;
-  }
-  /*	
-  //SF7 BW 250kHz
-  RFM_Write(0x1E,0x74); //SF7 CRC On
-  RFM_Write(0x1D,0x82); //250 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26,0x04); //Low datarate optimization off AGC auto on
-  */
-  //SF10 BW 125 kHz
-  RFM_Write(0x1E,0xA4); //SF10 CRC On
-  RFM_Write(0x1D,0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26,0x04); //Low datarate optimization off AGC auto on
- 
+
+ RFM_Write(0x06, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
+ RFM_Write(0x07, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
+ RFM_Write(0x08, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));
+
+#ifdef SF12BW125 //SF12 BW 125 kHz
+	RFM_Write(0x1E,0xC4); //SF12 CRC On
+	RFM_Write(0x1D,0x72); //125 kHz 4/5 coding rate explicit header mode
+	RFM_Write(0x26,0x0C); //Low datarate optimization on AGC auto on
+#endif 
+
+#ifdef SF11BW125 //SF11 BW 125 kHz
+	RFM_Write(0x1E,0xB4); //SF11 CRC On
+	RFM_Write(0x1D,0x72); //125 kHz 4/5 coding rate explicit header mode
+	RFM_Write(0x26,0x0C); //Low datarate optimization on AGC auto on
+#endif
+
+#ifdef SF10BW125 //SF10 BW 125 kHz
+	RFM_Write(0x1E,0xA4); //SF10 CRC On
+	RFM_Write(0x1D,0x72); //125 kHz 4/5 coding rate explicit header mode
+	RFM_Write(0x26,0x04); //Low datarate optimization off AGC auto on
+#endif
+
+#ifdef SF9BW125 //SF9 BW 125 kHz
+	RFM_Write(0x1E,0x94); //SF9 CRC On
+	RFM_Write(0x1D,0x72); //125 kHz 4/5 coding rate explicit header mode
+	RFM_Write(0x26,0x04); //Low datarate optimization off AGC auto on
+#endif
+
+#ifdef SF8BW125 //SF8 BW 125 kHz
+	RFM_Write(0x1E,0x84); //SF8 CRC On
+	RFM_Write(0x1D,0x72); //125 kHz 4/5 coding rate explicit header mode
+	RFM_Write(0x26,0x04); //Low datarate optimization off AGC auto on
+#endif
+
+#ifdef SF7BW125 //SF7 BW 125 kHz
+	RFM_Write(0x1E,0x74); //SF7 CRC On
+	RFM_Write(0x1D,0x72); //125 kHz 4/5 coding rate explicit header mode
+	RFM_Write(0x26,0x04); //Low datarate optimization off AGC auto on
+#endif
+
+#ifdef SF7BW250 //SF7 BW 250kHz
+	RFM_Write(0x1E,0x74); //SF7 CRC On
+	RFM_Write(0x1D,0x82); //250 kHz 4/5 coding rate explicit header mode
+	RFM_Write(0x26,0x04); //Low datarate optimization off AGC auto on
+#endif 
+
   //Set payload length to the right length
   RFM_Write(0x22,Package_Length);
 
@@ -170,6 +247,7 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
   //Switch RFM to sleep
   RFM_Write(0x01,0x00);
 }
+
 /*
 *****************************************************************************************
 * Description : Funtion that writes a register from the RFM
@@ -512,7 +590,12 @@ void TinyLoRa::Calculate_MIC(unsigned char *Data, unsigned char *Final_MIC, unsi
   Final_MIC[2] = New_Data[2];
   Final_MIC[3] = New_Data[3];
 	
-  randomNum = Final_MIC[3] & 0x03;
+  // Generate a random number between 0 and 7 to select next transmit channel 
+  randomNum = Final_MIC[3] & 0x07;
+
+  // Generate a random number between 0 and 7 to randomise next transmit message schedule
+  txrandomNum = Final_MIC[2] & 0x07;
+
 }
 /*
 *****************************************************************************************


### PR DESCRIPTION
Moved channel selection to programme memory, this extends the available channels to the full range 8.  Added regional frequency map selection and data rate selection, selected via #defines in ATtinyLoRa.h (only tested on AU915).  Exposed a new random variable in the public class, txrandomNum, this can be useful for randomising transmit times to help avoid conflict.